### PR TITLE
fix: Workaround Cannot read property '__STORYBOOK_ADDON_INTERACTIONS_…

### DIFF
--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -2,6 +2,10 @@ import type { StorybookConfig as StorybookConfigBase } from '@storybook/core/typ
 import type { ReactNativeOptions } from './Start';
 export { darkTheme, theme, type Theme } from '@storybook/react-native-theming';
 
+// @ts-ignore Workaround [TypeError: Cannot read property '__STORYBOOK_ADDON_INTERACTIONS_INSTRUMENTER_STATE__' of undefined]
+// from @storybook/test
+global.window.parent = global.window.parent || {};
+
 export { start, prepareStories, getProjectAnnotations, updateView } from './Start';
 
 export interface StorybookConfig {


### PR DESCRIPTION
…INSTRUMENTER_STATE__'

Issue:

## What I did

## How to test

Please explain how to test your changes and consider the following questions

- Does this need a new example in examples/expo-example?
- Does this need an update to the documentation?

If your answer is yes to any of these, please make sure to include it in your PR.

<!--

Everybody: Please submit all PRs to the `next-6.0` branch unless they are specific to 5.3. Storybook maintainers cherry-pick bug and documentation fixes into the `master` branch as part of the release process, so you shouldn't need to worry about this.

Maintainers: Please tag your pull request with at least one of the following:
`["cleanup", "BREAKING CHANGE", "feature request", "bug", "documentation", "maintenance", "dependencies", "other"]`

-->
